### PR TITLE
Add AlexGames matrix widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ Research papers and similar documents studying something related to Matrix.
   `Apache-2.0` `TypeScript`
 - [matrix-widget-debug](https://github.com/turt2live/matrix-widget-debug) - Test
   widget for validating clients and `matrix-widget-api`. `Apache-2.0` `JavaScript`
+- [AlexGames](https://github.com/alexbarry/AlexGames) - A simple board games
+  web app that works as a Matrix widget.
+  ([Chat](https://matrix.to/#/#alexgames:matrix.org)) `AGPL-3.0-only`
+  `Lua`/`JavaScript`/`Rust`/`C`
 
 ---
 


### PR DESCRIPTION
AlexGames is a collection of Lua and Rust games which can be built to web assembly and run in a browser. My original version uses a websocket server, but I created a prototype version that works as a matrix widget, see https://matrix.org/blog/2024/09/27/this-week-in-matrix-2024-09-27/#alexgames-simple-lua-rust-webassembly-powered-board-games-running-in-a-matrix-widget for more info.

Also, I included this link in my description, but it extends beyond 80 characters. I truncated the rest of the lines. Let me know if you'd rather I remove the link, I added it to my project's Github README, and it's in the Matrix room description.

<!-- Thank you for your submission to Awesome Matrix! 😄 -->

### Checklist

- [x] Use an informative PR title, such as "Add foo to bar"
- [x] Format each entry as follows, where "Repo" and "Chat" are examples of
  optional extra links:
```
- [Name](https://example.com/) - Short description, sentence case. ([Repo](https://github.com/foo/bar), [Chat](https://matrix.to/#/#room:example.com)) `License` `Language`
```
- [x] Append to the bottom of a section
- [x] Wrap lines to 80 characters
- [x] Use [SPDX license identifiers](https://spdx.org/licenses/) when possible
