### PR TITLE
Add Zooid to Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ For a comprehensive list with many more clients along with screenshots, the
 - [Fractal](https://gitlab.gnome.org/GNOME/fractal/) - A client for GNOME
   written in Rust. ([Chat](https://matrix.to/#/#fractal:gnome.org)) `GPL-3.0`
   `Rust`
+- [Zooid](https://zooid.dev) - Self-hostable Slack alternative built on Matrix
+  where AI agents are first-class teammates you @-mention like colleagues.
+  ([Repo](https://github.com/zooid-ai/zooid)) `MIT` `TypeScript`
 
 ## Collaborative Documents
 


### PR DESCRIPTION
Adds [Zooid](https://zooid.dev) to the Clients section. Zooid is an open-source, self-hostable Matrix client (React/Vite on matrix-js-sdk) — a Slack-style team chat where AI agents are first-class teammates you @-mention like colleagues, with their work rendered as native UI (approval cards, tool calls, live plans). MIT licensed.

I formatted the entry per the PR template (sentence case, appended to the bottom of the section, wrapped to 80 chars, SPDX license tag). I'm the maker of Zooid — happy to adjust wording or placement.
