### PR TITLE
Add jellyseerr-matrix-bot to Single Purpose Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ obvious category to fit into on the matrix.org website.
 
 Some bots are quick scripts tailored to a specific purpose.
 
+- [jellyseerr-matrix-bot](https://github.com/inventory69/jellyseerr-matrix-bot) -
+  Jellyseerr/Overseerr media request and issue notifications in an end-to-end
+  encrypted room, with posters, mention pills and push through muted rooms.
+  `MIT` `Python`
+
 ## Bridges
 
 ## Clients


### PR DESCRIPTION
Adds [jellyseerr-matrix-bot](https://github.com/inventory69/jellyseerr-matrix-bot):
Jellyseerr/Overseerr media request and issue notifications in an end-to-end
encrypted Matrix room, with posters (m.image with caption, MSC2530), mention
pills via user mapping, and pushes that survive rooms muted to "mentions only".

### Checklist

- [x] Use an informative PR title, such as "Add foo to bar"
- [x] Format each entry as follows, where "Repo" and "Chat" are examples of
  optional extra links:
```
- [Name](https://example.com/) - Short description, sentence case. ([Repo](https://github.com/foo/bar), [Chat](https://matrix.to/#/#room:example.com)) `License` `Language`
```
- [x] Append to the bottom of a section
- [x] Wrap lines to 80 characters
- [x] Use [SPDX license identifiers](https://spdx.org/licenses/) when possible